### PR TITLE
Update 2-createCsv.py

### DIFF
--- a/chapter5/2-createCsv.py
+++ b/chapter5/2-createCsv.py
@@ -1,7 +1,7 @@
 import csv
 #from os import open
 
-csvFile = open("../files/test.csv", 'w+')
+csvFile = open("../files/test.csv", 'w+', newline='')
 try:
     writer = csv.writer(csvFile)
     writer.writerow(('number', 'number plus 2', 'number times 2'))


### PR DESCRIPTION
`newline=''` should be added in `open()` when I create csv file on Windows, otherwise there will be an additional new line under every row at csv file.