### PR TITLE
'Look inside' functions better

### DIFF
--- a/chapter11/3-readWebImages.py
+++ b/chapter11/3-readWebImages.py
@@ -8,7 +8,7 @@ driver = webdriver.Firefox()
 driver.get("http://www.amazon.com/War-Peace-Leo-Nikolayevich-Tolstoy/dp/1427030200")
 time.sleep(2)
 
-driver.find_element_by_id("sitbLogoImg").click()
+driver.find_element_by_id("img-canvas").click()
 #The easiest way to get exactly one of every page
 imageList = set()
 


### PR DESCRIPTION
Before sometimes the way 'Look inside' renders in the browser (at least in
Linux), click would not register. So instead of click 'Look inside' click
the book image.