### PR TITLE
parameters mistake

### DIFF
--- a/chapter3/3-crawlSite.py
+++ b/chapter3/3-crawlSite.py
@@ -16,7 +16,7 @@ def getInternalLinks(bsObj, includeUrl):
             if link.attrs['href'] not in internalLinks:
                 internalLinks.append(link.attrs['href'])
     return internalLinks
-            
+
 #Retrieves a list of all external links found on a page
 def getExternalLinks(bsObj, excludeUrl):
     externalLinks = []
@@ -37,15 +37,17 @@ def getRandomExternalLink(startingPage):
     bsObj = BeautifulSoup(html)
     externalLinks = getExternalLinks(bsObj, splitAddress(startingPage)[0])
     if len(externalLinks) == 0:
-        internalLinks = getInternalLinks(startingPage)
-        return getNextExternalLink(internalLinks[random.randint(0, 
-                                  len(internalLinks)-1)])
+        internalLinks = getInternalLinks(bsObj, "")
+        if len(internalLinks) == 0:
+            return "http://oreilly.com"
+        else:
+            return getRandomExternalLink(internalLinks[random.randint(0, len(internalLinks) - 1)])
     else:
-        return externalLinks[random.randint(0, len(externalLinks)-1)]
-    
+        return externalLinks[random.randint(0, len(externalLinks) - 1)]
+
 def followExternalOnly(startingSite):
     externalLink = getRandomExternalLink("http://oreilly.com")
     print("Random external link is: "+externalLink)
     followExternalOnly(externalLink)
-            
+
 followExternalOnly("http://oreilly.com")


### PR DESCRIPTION
1. `def getInternalLinks(bsObj, includeUrl)`  has two parameters, but  `getInternalLinks(startingPage) ` has only one parameter and parameter type is not anastomotic. So we should change it to `getInternalLinks(bsObj, “”)`.
1. We should judge the length of internalLinks with `len(internalLinks)`.
1. We don’t have a function  named `getNextExternalLink`, I think `getNextExternalLink` should change to `getRandomExternalLink`.