### PR TITLE
Update 3-javascriptRedirect.py

### DIFF
--- a/chapter10/3-javascriptRedirect.py
+++ b/chapter10/3-javascriptRedirect.py
@@ -13,7 +13,7 @@ def waitForLoad(driver):
             return
         time.sleep(.5)
         try:
-            elem == driver.find_element_by_tag_name("html")
+            elem.get_attribute("innerHTML") == driver.find_element_by_tag_name("html").get_attribute("innerHTML")
         except StaleElementReferenceException:
             return
 


### PR DESCRIPTION
The following line 
elem == driver.find_element_by_tag_name("html")
will only generate True (the first 4 iterations) or False (the remaining 16 iterations).  
This statement does not trigger the StaleElementReferenceException, so the function always exits after 10 seconds and prints the "Timing out" message.
My suggestion is to access an element attribute (e.g., "innerHTML").  This will trigger the exception after the webpage is directed.