### PR TITLE
Update 6 readDocx.py --- an xml parser missing

### DIFF
--- a/chapter6/6-readDocx.py
+++ b/chapter6/6-readDocx.py
@@ -8,7 +8,7 @@ wordFile = BytesIO(wordFile)
 document = ZipFile(wordFile)
 xml_content = document.read('word/document.xml')
 
-wordObj = BeautifulSoup(xml_content.decode('utf-8'))
+wordObj = BeautifulSoup(xml_content.decode('utf-8').'xml')
 textStrings = wordObj.findAll("w:t")
 for textElem in textStrings:
     print(textElem.text)


### PR DESCRIPTION
In python3.5, I've tried commonly used parsers like "html.parser" and 'lxml', but neither worked. 
I mean when they are used, the command `wordObj.findAll("w:t")` always returns an empty list, whereas 'xml' gives back what I expect, which is

`[<w:t>A Word Document on a Website</w:t>, <w:t>This is a Word document, full of content that you want very much. Unfortunately, it’s difficult to access because I’m putting it on my website as a .</w:t>, <w:t>docx</w:t>, <w:t xml:space="preserve"> file, rather than just publishing it as HTML</w:t>]`.

Looking forward to your reply.  
This is a great book, and let's make it even better!