### PR TITLE
Import fix

### DIFF
--- a/Chapter05_Scrapy/wikiSpider/wikiSpider/articles.py
+++ b/Chapter05_Scrapy/wikiSpider/wikiSpider/articles.py
@@ -1,5 +1,5 @@
-from scrapy.contrib.linkextractors import LinkExtractor
-from scrapy.contrib.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 class ArticleSpider(CrawlSpider):
     name = 'articles'


### PR DESCRIPTION
Deprecation removals
Compatibility shims for pre-1.0 Scrapy module names are removed (issue 3318):
scrapy.contrib (with all submodules)
scrapy.contrib_exp (with all submodules)