### PR TITLE
Update articles.py

### DIFF
--- a/Chapter05_Scrapy/wikiSpider/wikiSpider/articles.py
+++ b/Chapter05_Scrapy/wikiSpider/wikiSpider/articles.py
@@ -1,5 +1,5 @@
-from scrapy.contrib.linkextractors import LinkExtractor
-from scrapy.contrib.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 
 class ArticleSpider(CrawlSpider):
     name = 'articles'


### PR DESCRIPTION
Changed `scrapy.contrib.linkextractors` and `scrapy.contrib.spiders` to `scrapy.linkextractors` and `scrapy.spiders` respectfully. 
Why? Because the latter was causing an Error due to the fact that  `scrapy.contrib` has been deprecated for ages now.
(https://docs.scrapy.org/en/latest/news.html#deprecation-removals)