### PR TITLE
Remove the `^` from regex that is looking for Wiki article links.

### DIFF
--- a/Chapter05_Scrapy/wikiSpider/wikiSpider/articlesMoreRules.py
+++ b/Chapter05_Scrapy/wikiSpider/wikiSpider/articlesMoreRules.py
@@ -6,7 +6,7 @@ class ArticleSpider(CrawlSpider):
     allowed_domains = ['wikipedia.org']
     start_urls = ['https://en.wikipedia.org/wiki/Benevolent_dictator_for_life']
     rules = [
-        Rule(LinkExtractor(allow='^(/wiki/)((?!:).)*$'), callback='parse_items', follow=True, cb_kwargs={'is_article': True}),
+        Rule(LinkExtractor(allow='(/wiki/)((?!:).)*$'), callback='parse_items', follow=True, cb_kwargs={'is_article': True}),
         Rule(LinkExtractor(allow='.*'), callback='parse_items', cb_kwargs={'is_article': False})
     ]
 


### PR DESCRIPTION
NOTE: This relates to page 73 as the same regex on page 78 doesn't contain the `^`.

The links being scraped are absolute (full) URLs. The rule should look for links that contain `/wiki/` rather than start with `/wiki/`. 